### PR TITLE
chore: add ArchiveExemption.txt to prevent automated archiving

### DIFF
--- a/ArchiveExemption.txt
+++ b/ArchiveExemption.txt
@@ -1,0 +1,1 @@
+This is an active repository supporting the Blaise 5 architecture.


### PR DESCRIPTION
This automated PR adds an `ArchiveExemption.txt` file to flag this repository as an active part of the Blaise 5 architecture and prevent automated archiving.